### PR TITLE
Dev

### DIFF
--- a/.github/workflows/latest-changes.yml
+++ b/.github/workflows/latest-changes.yml
@@ -2,7 +2,7 @@ name: Latest Changes
 on:
   pull_request_target:
     branches:
-      - master
+      - release-candidate
     types:
       - closed
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        python: ['3.9','3.8','3.7']
+        python: ['3.8','3.7','3.6']
     steps:
     - uses: actions/checkout@master
     - name: Python ${{ matrix.python }} version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        python: ['3.8','3.7', '3.6']
+        python: ['3.9','3.8','3.7']
     steps:
     - uses: actions/checkout@master
     - name: Python ${{ matrix.python }} version


### PR DESCRIPTION
Change of branch for latest changes to release-candidate
Python 3.9 is unsupported with Github actions testing. Will remove 3.6 when available.